### PR TITLE
Marked Brush Strokes and Burger Alarm as unplayable.

### DIFF
--- a/JSON/Brush Strokes.json
+++ b/JSON/Brush Strokes.json
@@ -1,6 +1,6 @@
 {
   "Author": "EpicToast, Blananas2, TasThing",
-  "Compatibility": "Compatible",
+  "Compatibility": "Unplayable",
   "DefuserDifficulty": "Medium",
   "Description": "Draw a certain symbol using rules from other manuals. Tags: 9-buttons, circles, colors",
   "ExpertDifficulty": "Medium",

--- a/JSON/Burger Alarm.json
+++ b/JSON/Burger Alarm.json
@@ -1,6 +1,6 @@
 {
   "Author": "EpicToast",
-  "Compatibility": "Compatible",
+  "Compatibility": "Unplayable",
   "DefuserDifficulty": "Medium",
   "Description": "Make a burger in a certain amount of time based on a bunch of tables. Tags: keypad, 7-segment-display, tick, cross, black-module, burger",
   "ExpertDifficulty": "Hard",


### PR DESCRIPTION
For an explanation, see #modding in KTaNE Discord server.
tl;dr
Brush Strokes doesn't reset upon a strike, and sometimes submits when it shouldn't.
Burger Alarm can display the incorrect digits.