### PR TITLE
Edit Reworded and Colored Simon's Stages Manual and Add TP scoring to Widgets

### DIFF
--- a/HTML/Simon’s Stages reworded and colored (VFlyer).html
+++ b/HTML/Simon’s Stages reworded and colored (VFlyer).html
@@ -163,7 +163,7 @@
                             <p>
                                 Succesfully inputting the full sequence correctly will disarm the module.
                             </p>
-                            <ul>* By default, <cite>Simon’s Stages</cite> will ignore modules such as <cite>Forget Me Not, Forget Everything, Souvenir, The Time Keeper, Turn the Key, The Swan</cite> and other instances of <cite>Simon’s Stages</cite>. This behavior may be altered.
+                            <ul>* By default, <cite>Simon’s Stages</cite> will ignore some modules and other instances of <cite>Simon’s Stages</cite>. This behavior may be altered.
                             </ul>
                         <h2>Terminology</h2>
                         <p>
@@ -198,7 +198,7 @@
                             From the example provided, red is opposite to green, blue is opposite to pink, yellow is opposite to lime, orange is opposite to cyan, and magenta is opposite to white.
                         </p>
                         <p>
-                            So if the color of the flashing sequence is white, orange, pink, and you needed to input colors opposite in the sequence, you would input magenta, cyan, blue for this condition because magenta is opposite to white, cyan is opposite to orange, and blue is opposite to pink.
+                            So if the colour of the flashing sequence is white, orange, pink, and you needed to input colours opposite in the sequence, you would input magenta, cyan, blue for this condition because magenta is opposite to white, cyan is opposite to orange, and blue is opposite to pink.
                         </p>
                     </div>
                     <div class="page-footer relative-footer">Page 2 of 2</div>

--- a/JSON/Batteries.json
+++ b/JSON/Batteries.json
@@ -9,5 +9,6 @@
   "SortKey": "BATTERIES",
   "Souvenir": { "Status": "NotACandidate" },
   "SteamID": null,
+  "TwitchPlays": {},
   "Type": "Widget"
 }

--- a/JSON/Date of Manufacture.json
+++ b/JSON/Date of Manufacture.json
@@ -10,5 +10,6 @@
   "SourceUrl": "https://github.com/Rocket0634/DayTime-Widget",
   "Souvenir": { "Status": "NotACandidate" },
   "SteamID": "1594957772",
+  "TwitchPlays": {},
   "Type": "Widget"
 }

--- a/JSON/Encrypted Indicators.json
+++ b/JSON/Encrypted Indicators.json
@@ -10,5 +10,6 @@
   "SourceUrl": "https://github.com/Trainzack/KTANEEncryptedIndicators",
   "Souvenir": { "Status": "NotACandidate" },
   "SteamID": "1060194010",
+  "TwitchPlays": {},
   "Type": "Widget"
 }

--- a/JSON/Indicators.json
+++ b/JSON/Indicators.json
@@ -9,5 +9,6 @@
   "SortKey": "INDICATORS",
   "Souvenir": { "Status": "NotACandidate" },
   "SteamID": null,
+  "TwitchPlays": {},
   "Type": "Widget"
 }

--- a/JSON/Modded Ports.json
+++ b/JSON/Modded Ports.json
@@ -10,5 +10,6 @@
   "SourceUrl": "https://github.com/nasko222/moddedports-master",
   "Souvenir": { "Status": "NotACandidate" },
   "SteamID": "1799107064",
+  "TwitchPlays": {},
   "Type": "Widget"
 }

--- a/JSON/Multiple Widgets.json
+++ b/JSON/Multiple Widgets.json
@@ -10,5 +10,6 @@
   "SourceUrl": "https://github.com/CaitSith2/KTANE-mods/tree/master/MultipleWidgets",
   "Souvenir": { "Status": "NotACandidate" },
   "SteamID": "1112930514",
+  "TwitchPlays": {},
   "Type": "Widget"
 }

--- a/JSON/Numbered Indicators.json
+++ b/JSON/Numbered Indicators.json
@@ -10,5 +10,6 @@
   "SourceUrl": "https://github.com/KingBranBran/Ktane-NumberedIndicators",
   "Souvenir": { "Status": "NotACandidate" },
   "SteamID": "1367941984",
+  "TwitchPlays": {},
   "Type": "Widget"
 }

--- a/JSON/Ports.json
+++ b/JSON/Ports.json
@@ -9,5 +9,6 @@
   "SortKey": "PORTS",
   "Souvenir": { "Status": "NotACandidate" },
   "SteamID": null,
+  "TwitchPlays": {},
   "Type": "Widget"
 }

--- a/JSON/Two Factor.json
+++ b/JSON/Two Factor.json
@@ -10,5 +10,6 @@
   "SourceUrl": "https://github.com/timtmok/ktanemod-twofactor",
   "Souvenir": { "Status": "NotACandidate" },
   "SteamID": "737234129",
+  "TwitchPlays": {},
   "Type": "Widget"
 }


### PR DESCRIPTION
Widgets being set to 0 pts are:
Batteries
Date of Manufacture
Encrypted Indicators
Indicators
Modded Ports
Multiple Widgets
Numbered Indicators
Ports
Two Factor

Manuals edited are:
Simon's Stages Reworded and Colored (VFlyer)
- Fix inconsistency error on US/EU spelling (color versus colour)
- Change "ignores" text to be nearly in-line with original manual
