### PR TITLE
Small typo in Neutrinos manual

### DIFF
--- a/HTML/Neutrinos.html
+++ b/HTML/Neutrinos.html
@@ -88,7 +88,7 @@
 						</tr>
 						</table>
 						<br>
-						<li>Values a, b, and c should be concatenated together (abc) and then apply the global modulo to this new 3-digit number. Then divide by 1000. The momentum is:<br><center><strong>p = 1.2 - (abc/1000 % Global Modulo)</strong></center></li>
+						<li>Values a, b, and c should be concatenated together (abc) and then apply the global modulo to this new 3-digit number. Then divide by 1000. The momentum is:<br><center><strong>p = 1.2 - ((abc % Global Modulo)/1000)</strong></center></li>
 						<br>
 						<li>Next calculate the speed (<strong>β</strong>) by dividing the momentum by the neutrino mass. If you get a speed of <strong>1</strong> then you broke physics, press submit and don't tell anyone. Make sure you round each of the following calculations to 3 decimal places (ex. 1.87746 ≅ 1.877, 1.87756 ≅ 1.878)<br><center><strong>β = p/1.2</center></strong></li>
 						<br>


### PR DESCRIPTION
The formula for step 2 of calculating the travel time does not match the text of step 2.