### PR TITLE
Lazy match for Rainbow Arrows LFA

### DIFF
--- a/More/Logfile Analyzer.js
+++ b/More/Logfile Analyzer.js
@@ -5229,7 +5229,7 @@ $(function() {
 				loggingTag: "Rainbow Arrows",
 				matches: [
 					{
-						regex: /^\((.+)\) (.+)/,
+						regex: /^\((.+?)\) (.+)/,
 						handler: function(matches, module) {
 							if (module.length === 0 || module[module.length-1][0] !== matches[1]) {
 								module.push([matches[1], [], false]);


### PR DESCRIPTION
"(North - Maze Navigation) Starting position (6) and ending position (6) are the same."
This is a rather uncommon edge case, so I missed it when I was making sure everything worked. Greedy match returns a result of "North - Maze Navigation) Starting position (6) and ending position (6", which is obviously wrong.