### PR TITLE
Update Steam IDs for 6 Modules

### DIFF
--- a/JSON/15 Mystic Lights.json
+++ b/JSON/15 Mystic Lights.json
@@ -10,6 +10,6 @@
   "Published": "2019-12-18",
   "SortKey": "15MYSTICLIGHTS",
   "Souvenir": { "Status": "NotACandidate" },
-  "SteamID": 1940129772,
+  "SteamID": 1940164898,
   "Type": "Regular"
 }

--- a/JSON/3x3 Grid.json
+++ b/JSON/3x3 Grid.json
@@ -9,7 +9,7 @@
   "Origin": "Mods",
   "Published": "2019-12-18",
   "SortKey": "3X3GRID",
-  "SteamID": 1940129772,
+  "SteamID": 1940164898,
   "TwitchPlays": {
     "AutoPin": true,
     "NeedyScoring": "Solves",

--- a/JSON/BuzzFizz.json
+++ b/JSON/BuzzFizz.json
@@ -9,7 +9,7 @@
   "Origin": "Mods",
   "Published": "2019-12-18",
   "SortKey": "BUZZFIZZ",
-  "SteamID": 1940129772,
+  "SteamID": 1940164898,
   "TwitchPlays": {
     "AutoPin": true,
     "NeedyScoring": "Solves"

--- a/JSON/Forget It Not.json
+++ b/JSON/Forget It Not.json
@@ -35,7 +35,7 @@
   "Published": "2019-12-18",
   "SortKey": "FORGETITNOT",
   "Souvenir": { "Status": "NotACandidate" },
-  "SteamID": 1940129772,
+  "SteamID": 1940164898,
   "TwitchPlays": {
     "AutoPin": true,
     "ScorePerModule": 0.25

--- a/JSON/Time Accumulation.json
+++ b/JSON/Time Accumulation.json
@@ -9,6 +9,6 @@
   "Origin": "Mods",
   "Published": "2019-12-18",
   "SortKey": "TIME ACCUMULATION",
-  "SteamID": 1940129772,
+  "SteamID": 1940164898,
   "Type": "Needy"
 }

--- a/JSON/❖.json
+++ b/JSON/❖.json
@@ -9,7 +9,7 @@
   "Origin": "Mods",
   "Published": "2019-12-18",
   "SortKey": "SIMONNONVERBAL",
-  "SteamID": 1940129772,
+  "SteamID": 1940164898,
   "TwitchPlays": { "Score": 5 },
   "Type": "Regular"
 }


### PR DESCRIPTION
The old version is deleted. The pull request updates the steam ID to the more recent version

* Update 15 Mystic Lights.json

* Update ❖.json

* Update Forget It Not.json

* Update 3x3 Grid.json

* Update BuzzFizz.json

* Update Time Accumulation.json