### PR TITLE
Fix #689

### DIFF
--- a/HTML/js/ktane-utils.js
+++ b/HTML/js/ktane-utils.js
@@ -85,8 +85,8 @@ e.onload = function()
 
         $(document).keydown(function(event)
         {
-            // Only accept shortcuts with Alt
-            if (!event.altKey || event.shiftKey || event.ctrlKey)
+            // Only accept shortcuts with Alt or Ctrl+Shift
+            if ((!event.altKey && !(event.shiftKey && event.ctrlKey))
                 return;
 
             // Alt-O: Open options menu

--- a/HTML/js/ktane-utils.js
+++ b/HTML/js/ktane-utils.js
@@ -86,7 +86,7 @@ e.onload = function()
         $(document).keydown(function(event)
         {
             // Only accept shortcuts with Alt or Ctrl+Shift
-            if ((!event.altKey && !(event.shiftKey && event.ctrlKey))
+            if (!event.altKey && !(event.shiftKey && event.ctrlKey))
                 return;
 
             // Alt-O: Open options menu


### PR DESCRIPTION
Ctrl+Shift is already used as a replacement for Alt when clicking, can we do it here too in order to support Firefox?