### PR TITLE
Reword ucr+ur(1)

### DIFF
--- a/HTML/Unfair’s Cruel Revenge.html
+++ b/HTML/Unfair’s Cruel Revenge.html
@@ -61,7 +61,7 @@
                 <h2>On the Subject of Unfair’s Cruel Revenge</h2>
                 <p class="flavour-text">He made two versions of Unfair’s Revenge because he wanted something more unfair than just the base idea... Was it unfair enough in the first place?</p>
                 <p>To distinguish this from Unfair Cipher and Unfair’s Revenge, the 2 displays on this module are identical with one of them being rotated. The display on top shows the encrypted message. There’s also a strip of LEDs underneath which will light up to show the current stage the defuser is on.</p>
-                <p>The display on the right can be clicked to cycle between showing the Module ID, in white, strikes the module is keeping track of, in red, and the extra key. The Module ID and the strike counter are either shown in fixed or broken Roman numerals, or in Arabic form, I.E 1, 2, 3, 5,...</p>
+                <p>The display on the right can be clicked to cycle between showing the Module ID, in white, strikes the module is keeping track of, in red, and the extra key. The Module ID and the strike counter are either shown in fixed or broken Roman numerals, or in Arabic form, I.E 1, 2, 3, 5, ... Refer to <a href="Roman%20Art%20censored.html">Roman Art</a> for a reference to Broken and Fixed Roman Numerals. 0 in Fixed/Broken Roman Numerals will be shown as literally nothing on the module and "0" in Arabic form.</p>
                 <p class="red"><strong>For all operations involving STRIKES, always refer to the number in red on the module itself.</strong></p>
                 <p>The module encrypts a string of six distant three-letter-long <span style="text-decoration: underline">instructions</span> with different ciphers, using different <strong>keys</strong> for each. Enter the correct combination of inputs to disarm the module.</p>
                 <p><strong>ALL ciphers referring to the alphabet refers to the A1Z26 standard for each letter unless stated otherwise. Alphabetical order is ALSO modified for the ciphers!</strong></p>
@@ -69,18 +69,13 @@
                     <li>The basic order of the given encrypted text is the following: <strong>Original -> 5x Ciphers -> Pigpen Ciphered.</strong> Reverse the order to obtain the <strong>original</strong> instruction string.</li>
                 </ul>
                 <h3>Key A</h3>
-                <ol style="font-size: 15px">
+                <ol>
                     <li>Start with the bomb’s serial number.</li>
                     <li>Interpret each character as a base-36 digit.</li>
                     <ul>
                         <li>If the character is unfamiliar in the set of base-36 digits, interpret this character as the digit "I".</li>
                     </ul>
                     <li>Convert this base-36 number into <strong>hexadecimal.</strong> You can do this by converting the base-36 value into base-10 and then converting the base-10 value into hexadecimal. Refer to <span class="itil">Appendix HexDex</span> for instructions to convert base-10 into hexadecimal and <span class="itil">Appendix Base-36 Conversion</span> for converting base-36 into base-10.</li>
-                    <li>Now read the string of hexadecimal digits as a string of decimal digits and letters. Going from left to right, for every digit:</li>
-                    <ul>
-                        <li>If the digit is followed by another digit and they form a number in the range 10–26, convert the pair into its alphabetical equivalent.</li>
-                        <li>Otherwise, convert the single digit into its alphabetical equivalent, or skip it if it is a zero.</li>
-                    </ul>
                 </ol>
             </div>
             <div class="page-footer relative-footer">Page 1 of 17</div>
@@ -91,10 +86,14 @@
                 <span class="page-header-section-title">Unfair’s Cruel Revenge</span>
             </div>
             <div class="page-content">
-
-                <ol start="5">
-                    <li>Transform the Module ID, (1 + the number of port plates), and (2 + the number of battery holders) into their alphabetical equivalents, using step 4 if necessary.</li>
-                    <li>Append these characters at the end of the result of the previous conversion.</li>
+                <ol start="4">
+                    <li>Now read the string of hexadecimal digits as a string of decimal digits and letters. Going from left to right, for every digit:</li>
+                    <ul>
+                        <li>If the digit is followed by another digit and they form a number in the range 10–26, convert the pair into its alphabetical equivalent.</li>
+                        <li>Otherwise, convert the single digit into its alphabetical equivalent, or skip it if it is a zero.</li>
+                    </ul>
+                    <li>Transform the Module ID, (1 + the number of port plates), and (2 + the number of battery holders) into their alphabetical equivalents, separately, using step 4 if any of these are greater than 26.</li>
+                    <li>Append these characters together and then at the end of the result of the previous conversion.</li>
                     <li><strong>This is Key A.</strong></li>
                 </ol>
                 <h3>Key B</h3>
@@ -229,7 +228,7 @@
                 <p>Use a Playfair Cipher to encode Key A using Key B as the keyword. The alphabet used is the Modern English Alphabet for this encryption. <strong>This is Key C.</strong></p>
                 <p>Refer to <span class="itil">Appendix PL4YF4112 101</span> for instructions.</p>
                 <h3>Key D</h3>
-                <p>Sum up the value of ALL the false rules in <a href="Alphabetize.html">Alphabetize</a>, as if there are no strikes, no solved modules on the bomb, which is determined by the position in the table, 1 being the top-most row. Then take the average of the sum. If this results in a decimal answer, use the 15th row on that manual as Key D, otherwise count that many rows from the top and use that as Key D.</p>
+                <p>Sum up the value of ALL the false rules in <a href="Alphabetize.html">Alphabetize</a>, as if there are no strikes, no solved modules on the bomb, which is determined by the position in the table, 1 being the top-most row. Then take the average of the sum. If this result is not an integer, use the 15th row on that manual as Key D, otherwise count that many rows from the top and use that as Key D.</p>
             </div>
             <div class="page-footer relative-footer">Page 2 of 17</div>
         </div>
@@ -490,7 +489,7 @@
             <div class="page-content">
                 <h2>Solving — Step 3: Modifying the Base Alphabet</h2>
                 <p class="flavour-text">Did he put a "Blue Arrows" in "Unfair’s Revenge?" Don't tell me he did...</p>
-                <p>You will need to modify the starting alphabet in order to use the ciphers and transpositions on the next set of pages when the modified alphabet is needed.</p>
+                <p>You will need to modify the starting alphabet in order to use the ciphers and transpositions on the next set of pages when the modified alphabet is needed. To get the modified alphabet:</p>
                 <ol>
                     <li>Start the alphabet with "ABCDEFGHIJKLMNOPQRSTUVWXYZ".</li>
                     <li>Shift the entire alphabet to the right [1 + the last digit of the serial number (10 if none)] times.</li>
@@ -524,7 +523,7 @@
                     </tr>
                     <tr>
                         <td>Even number of batteries</td>
-                        <td>Take the letters where the current 1-start position in the string has exactly 3 or 4 distant factors divisible by its position, reverse that set, and then put the resulting set to the back of the string.</td>
+                        <td>Take the letters where the position in the string (the first letter in the string being position 1) has exactly 3 or 4 distinct factors (including 1 and itself), reverse that set, and append it to the back of the string.</td>
                     </tr>
                     <tr>
                         <td>"Green Arrows", "The Sphere", or "Yellow Arrows" are present</td>
@@ -674,7 +673,7 @@
             </div>
             <div class="page-content">
                 <h2>Solving — Step ?: Playfair Cipher (Key X)</h2>
-                <p>Use a Playfair Cipher with Key X as the keyword to decrypt the string you just deciphered.</p>
+                <p>Use a Playfair Cipher with Key X as the keyword to decrypt the string you just deciphered. Use the modified alphabet you created for step 3 to fill in the rest.</p>
                 <p>Refer to <span class="itil">Appendix PL4YF4112 101</span> for instructions.</p>
                 <h2>Solving — Step ?: Atbash Cipher</h2>
                 <p>Each letter is encrypted to the alphabetical position of (27 - P), where P is the alphabetical position of the unencrypted letter.<br>
@@ -1281,6 +1280,7 @@
                         </td>
                     </tr>
                 </table>
+                <p class="flavour-text">Go <a href="https://crypto.interactive-maths.com/autokey-cipher.html">here</a> for information about Autokey cipher.</p>
             </div>
             <div class="page-footer relative-footer">Page 12 of 17</div>
         </div>

--- a/HTML/Unfair’s Revenge.html
+++ b/HTML/Unfair’s Revenge.html
@@ -68,8 +68,8 @@
                     </ul>
                 </ol>
                 <ol start="3">
-                    <li>Convert this base-36 number into decimal. Use <span class="itil">Appendix Base-36 Conversion</span> in case for reference. You will need to append this to the result of the next step.</li>
-                    <li>Grab the bomb’s last 3 serial number characters and transform each letter into its numerical equivalent (A=1,B=2,etc.).</li>
+                    <li>Convert this base-36 number into decimal. Use <span class="itil">Appendix Base-36 Conversion</span> in case for reference. You will need to prepend this to the result of the next step.</li>
+                    <li>Grab the bomb’s last 3 serial number characters and transform each letter into its numerical equivalent (A = 1, B = 2, etc.).</li>
                     <ul>
                         <li>Make this a single string of digits.</li>
                     </ul>
@@ -95,8 +95,8 @@
                     </ul>
                 </ol>
                 <ol start="8">
-                    <li>Transform the Module ID, the number of port plates and the number of battery holders into their alphabetical equivalents, using step 7 if necessary.</li>
-                    <li>Append these characters at the end of the result of the previous conversion.</li>
+                    <li>Transform the Module ID, the number of port plates and the number of battery holders into their alphabetical equivalents, separately, using step 7 if any of these are greater than 26.</li>
+                    <li>Append these characters together, and then at the end of the result of the previous conversion.</li>
                     <li><strong>This is Key A.</strong></li>
                 </ol>
                 <h3>Key B</h3>


### PR DESCRIPTION
- Replace unsafe link with a safer link for the Autokey Cipher reference.
- Clarification on the "Even number of batteries" action, courtesy of UltraCBoy
- Add reference to Roman Art.
- Clarified the section containing Module ID, Port Plates, Battery Holders for both manuals.
- Swap "append" with "prepend" on step 3.
Git stats
