### PR TITLE
Correctly place page headers with RuleSeed

### DIFF
--- a/HTML/js/ruleseed.js
+++ b/HTML/js/ruleseed.js
@@ -107,25 +107,43 @@ class MonoRandom
     }
 }
 
-var presumedModuleName = null;
+const names = {};
 
 function ruleseedInvokeSetRules()
 {
-    if (presumedModuleName === null)
-        presumedModuleName = document.getElementsByClassName('page-header-section-title')[0].innerText;
-
+	let sectionElements = Array.from(document.getElementsByClassName('page-header-section-title'));
+	// Checking if the names object has a length of 0 so that we don't initialize it twice.
+	if(Object.entries(names).length === 0) {
+		let i = 0;
+		// Stores the headers by the id indency.
+		sectionElements.forEach(x => {
+			names[i] = x.innerText;
+			x.setAttribute('name-id', i);
+			i++;
+		});
+	}
+	
+	// Whether the URL contains a seed.
     if (/^#(\d+)$/.exec(window.location.hash) && (RegExp.$1 | 0) !== 1)
     {
         var seed = RegExp.$1 | 0;
         document.body.classList.add('ruleseed-active');
         Array.from(document.getElementsByClassName('ruleseed-header')).forEach(x => { x.innerText = 'RULE SEED: ' + seed });
-        Array.from(document.getElementsByClassName('page-header-section-title')).forEach(x => { x.classList.add('ruleseed-seeded'); x.innerText = presumedModuleName + ' — rule seed: ' + seed; });
+		
+		// Iterate over each page header section title element, add the 'ruleseed-seeded' class, get the actual section title by using the custom 'name-id' attribute and appending the rule seed value.
+        sectionElements.forEach(x => { 
+			x.classList.add('ruleseed-seeded'); 
+			x.innerText = names[x.getAttribute('name-id')] + ' — rule seed: ' + seed; 
+		});
         setRules(new MonoRandom(seed));
     }
     else
     {
         document.body.classList.remove('ruleseed-active');
-        Array.from(document.getElementsByClassName('page-header-section-title')).forEach(x => { x.classList.remove('ruleseed-seeded'); x.innerText = presumedModuleName; });
+        sectionElements.forEach(x => { 
+			x.classList.remove('ruleseed-seeded'); 
+			x.innerText = names[x.getAttribute('name-id')];
+		});
         setDefaultRules(new MonoRandom(1));
     }
 }


### PR DESCRIPTION
RuleSeed will assume each page has the same header, but in modules like [hexOS](https://ktane.timwi.de/HTML/hexOS.html) not all pages have the same header.

This commit appends each page's header individually, then assigns them in order whenever needed.