### PR TITLE
Fixed Commands on Mislocation Interactive Manual

### DIFF
--- a/HTML/Mislocation interactive (Darksly).html
+++ b/HTML/Mislocation interactive (Darksly).html
@@ -344,6 +344,7 @@
                         onKeyDown(undoEvent.event, true);
                     } else if(undoEvent.action == "keyoverride") {
                         copiedCells = isUndo ? undoEvent.event : undoEvent.eventRedo;
+                        if(isRedo && undoEvent.beforePasteSelection) toggleCell(undoEvent.beforePasteSelection[0], true)
                         pasteSelection(true, isUndo);
                         if(isUndo && undoEvent.beforePasteSelection) undoMovement(undoEvent.beforePasteSelection);
                         copiedCells = [];
@@ -452,6 +453,7 @@
                         if(!isSelectionEmpty()) {
                             let savedStates = [];
                             let redoStates = [];
+
                             selectedCells.forEach(cell => {
                                 if(!undoForced) savedStates.push({
                                     content:cell.innerHTML,
@@ -559,7 +561,7 @@
                     case 88: // Cut
                         if(e.ctrlKey) {
                             copySelection();
-                            onKeyDown(new KeyboardEvent("onkeydown", { keyCode: 46 }), true);
+                            onKeyDown(new KeyboardEvent("onkeydown", { keyCode: 46 }));
                         }
                         return;
                 }


### PR DESCRIPTION
Fixed Undo and Redo Commands not working properly when trying to recall a "Ctrl + X "or "Delete" Command.