### PR TITLE
Allow setting parent of highlightable by class

### DIFF
--- a/HTML/js/ktane-utils.js
+++ b/HTML/js/ktane-utils.js
@@ -251,7 +251,7 @@ e.onload = function()
                     }
                     else
                     {
-                        let table = element.parents("table").first();
+                        let table = element.parents("table, .highlightable-parent").first();
 
                         let a;
                         let b;


### PR DESCRIPTION
Allow setting parent of highlightable by adding "highlight-parent" class to the element.

This allow us to use ctrl+click and shift+click to highlight row/column of element that is not a table.