### PR TITLE
Fix highlighter enabled setting

### DIFF
--- a/HTML/js/ktane-utils.js
+++ b/HTML/js/ktane-utils.js
@@ -381,7 +381,7 @@ e.onload = function()
 
         // Read current preferences from local storage
         let highlighterEnabled = localStorage.getItem('ktane-highlighter-enabled');
-        $('#highlighter-enabled').prop('checked', highlighterEnabled === null ? true : highlighterEnabled);
+        $('#highlighter-enabled').prop('checked', highlighterEnabled === null ? true : highlighterEnabled == "true");
         let pageLayout = localStorage.getItem('ktane-page-layout') || 'vertical';
         $(`#page-layout-${pageLayout}`).prop('checked', true);
         updateMultipageView();


### PR DESCRIPTION
Currently, disabling/enabling the highlighter sets the `ktane-highlighter-enabled` localStorage property, but the line that checks said property checks the value as a string. Since any string will just return `true`, the box will always be checked, even if the localStorage value is `"false"`.
So I've fixed that.