### PR TITLE
Fix missing logging when the solution has no valid tiles (noten)

### DIFF
--- a/More/Logfile Analyzer Data.js
+++ b/More/Logfile Analyzer Data.js
@@ -5417,6 +5417,12 @@ let parseData = [
                 }
             },
             {
+                regex: /(Solution:|Strike! Answer submitted:|Solved! Answer submitted:) ?$/,
+                handler: function (matches, module) {
+                    module.push(matches[0] + ' No tiles');
+                }
+            },
+            {
                 regex: /(Explanation:) (.*)$/,
                 handler: function (matches, module) {
                     const fileNames = {


### PR DESCRIPTION
When the solution/submission is empty, the LFA was not outputting a relevant piece of information