### PR TITLE
Allow ctrl+# for highlight color selection

### DIFF
--- a/HTML/js/ktane-utils.js
+++ b/HTML/js/ktane-utils.js
@@ -29,8 +29,8 @@ e.onload = function()
         }
 
         // Some users can't use Alt+<number> to select highlight colors. Setting this localStorage item (to anything) allows them to use Ctrl instead.
-        // There's no UI equivalent, because of how rarely this change is necessary.
-        // Note: this change _only_ applies to the highlight color selection; other keybinds like Alt-o and Alt-c remain on Alt.
+        // There's no option in the UI to enable this, because of how rarely it's necessary.
+        // Note: this change _only_ applies to the highlight color selection; other keybinds like Alt-O and Alt-C remain on Alt.
         let ctrlSelectsColors = localStorage.getItem('ktane-ctrl-selects-colors') !== null;
 
         // OPTIONS MENU
@@ -147,6 +147,7 @@ e.onload = function()
         $(document).keydown(function(event)
         {
             let n = extractNumberKey(event);
+
             // Special case: Ctrl+# instead of Alt+#
             if(
                 ctrlSelectsColors && n !== null

--- a/HTML/js/ktane-utils.js
+++ b/HTML/js/ktane-utils.js
@@ -154,6 +154,7 @@ e.onload = function()
                 && event.ctrlKey && !event.altKey && !event.shiftKey && !event.metaKey
             ) {
                 colorSelect.val(n).change();
+                return;
             }
 
             // Only accept shortcuts with Alt or Ctrl+Shift


### PR DESCRIPTION
Solves #1327. I decided to forgo adding a UI option entirely, because hardly anyone should need to use this feature. I haven't yet found any interactive manuals that this conflicts with (preventDefault is never called on the event, so everything should keep working)