### PR TITLE
Update Sword of Damocles compatability.

### DIFF
--- a/JSON/Sword of Damocles.json
+++ b/JSON/Sword of Damocles.json
@@ -1,6 +1,7 @@
 {
   "Author": "Deaf",
-  "Compatibility": "Compatible",
+  "Compatibility": "Unplayable",
+  "CompatibilityExplanation": "Interacts poorly with boss modules due to its auto-solve mechanic.",
   "DefuserDifficulty": "VeryEasy",
   "Description": "Double or nothing: The module. Tags: big sword, pit of wires, wires, wire, rope, wire",
   "ExpertDifficulty": "VeryEasy",


### PR DESCRIPTION
When playing around with this module, I discovered that its core mechanic (solving a module will randomly solve another one) can make it very easy to softlock yourself out of being able to finish certain types of boss modules. Because of this, I believe this module is a good candidate for marking as unplayable.