### PR TITLE
Iconic interactive: by default, pull icons from Iconic's GitHub repo

### DIFF
--- a/HTML/Iconic interactive (Kaito Sinclaire).html
+++ b/HTML/Iconic interactive (Kaito Sinclaire).html
@@ -29,6 +29,10 @@
         bottom: 0;
         color: #000;
     }
+    .repo-toggle-notice {
+        font-size: 11px;
+        font-style: italic;
+    }
     .result {
         font-size: 72pt;
     }
@@ -54,7 +58,7 @@
         text-align: center;
         margin: auto;
     }
-    input {
+    .module-input-box {
         width: 96%;
         font-family: 'Special Elite', 'Courier New', monospace;
         font-size: 12pt;
@@ -69,7 +73,7 @@
         "Y", "Z", "AA", "AB", "AC", "AD", "AE", "AF",
     ];
     module_icons = {
-        "...?": "Punctuation Marks.png",
+        "...?": "...q.png",
         "A>N<D": "A_N_D.png",
         "int##": "int__.png",
     };
@@ -115,11 +119,16 @@
     }
     fetchRepoInformation();
 
-    function updateIcon(element) {
-        var modname = element.value;
+    function updateIcon() {
+        var modname = document.getElementById("modinput").value;
         if (module_icons[modname] !== undefined) {
-            document.getElementById("icon").src = "https://ktane.timwi.de/Icons/" + encodeURI(module_icons[modname]);
+            // We still want to keep the manual repo as an option, just in case GitHub is down or something bad happens
+            var baseurl = (document.getElementById("repotoggle").checked)
+                ? "https://ktane.timwi.de/Icons/"
+                : "https://raw.githubusercontent.com/Blananas2/ktane-iconic/master/Assets/Icons/";
+            document.getElementById("icon").src = baseurl + encodeURI(module_icons[modname]);
         } else {
+            // It doesn't really matter where we fetch this from.
             document.getElementById("icon").src = "https://ktane.timwi.de/Icons/Blank.png";
         }
     }
@@ -156,13 +165,17 @@
                 <div class="containers">
                     <div class="input-container">
                         <div class="input-box">
-                            <input list="modules" id="modinput" oninput="updateIcon(this)">
+                            <input class="module-input-box" list="modules" id="modinput" oninput="updateIcon()">
                             <datalist id="modules">
                             </datalist>
                         </div>
                         <div class="location-box">
                             <div>Location:</div>
                             <div id="result" class="result">-</div>
+
+                            <input type="checkbox" id="repotoggle" oninput="updateIcon()">
+                            <label for="repotoggle">Use icons from the manual repo</label>
+                            <p class="repo-toggle-notice">Use this option at your own risk. The icons on the manual repo may differ from the ones Iconic uses.</p>
                         </div>
                     </div>
                     <div class="icon-container">


### PR DESCRIPTION
The differences between Iconic and the manual repo were making it difficult to use the interactive for its intended purpose. So, instead, load icons from Iconic's own repository (and allow using the manual repo as a fallback, in case GitHub is down; not an unheard of thing) so that they stay in line with what shows on the module.