### PR TITLE
Iconic int: Fix apostrophe issues dug up by recent change

### DIFF
--- a/HTML/Iconic interactive (Kaito Sinclaire).html
+++ b/HTML/Iconic interactive (Kaito Sinclaire).html
@@ -76,6 +76,9 @@
         "...?": "...q.png",
         "A>N<D": "A_N_D.png",
         "int##": "int__.png",
+
+        // These ones are needed for Iconic's repo specifically, and don't cause problems for the manual repo.
+        "Simon's On First": "Simon's on First.png",
     };
     /*
      * Aliases for module that is hard to search in English alphabet.
@@ -95,6 +98,9 @@
 
         var datalist = document.getElementById("modules");
         all_modules["KtaneModules"].forEach(mod => {
+            if (!["Regular", "Needy"].includes(mod["Type"]))
+                return; // Don't show things that aren't modules
+
             var name = mod["Name"].replace("’", "'");
             var newopt = document.createElement("option");
             newopt.value = name;
@@ -102,7 +108,7 @@
 
             if (module_icons[name] === undefined)
             {
-                var cleanname = name.replace("'", "’").replace("?", "").replace("/", "");
+                var cleanname = name.replace("?", "").replace("/", "");
                 module_icons[name] = cleanname + ".png";
             }
 


### PR DESCRIPTION
- Filenames for icons should not include the fancy apostrophe
- Don't show Widgets and Holdables in the dropdown