### PR TITLE
Removed FAQ text from FAQs.html (Glossary)

### DIFF
--- a/More/FAQs.html
+++ b/More/FAQs.html
@@ -64,6 +64,10 @@
                 margin: 0;
             }
 
+        article {
+            padding-top: 3em;
+        }
+
         section {
             margin: 0 auto;
             padding-top: 10vh;
@@ -340,7 +344,6 @@
 </head>
 <body>
     <h1>
-        FAQ
         <a class='back' href='/'>back</a>
     </h1>
     <article>


### PR DESCRIPTION
Removed the FAQ text on top of the Glossary, since that is not fitting. Would also be great to rename FAQs.html to Glossary.html, but I cannot find a way to make redirecting to the new file name work on the website :P