### PR TITLE
Add bag system for quiz questions

### DIFF
--- a/More/Quiz.html
+++ b/More/Quiz.html
@@ -28,6 +28,18 @@
                 a.onclick = function() { startQuiz(a.dataset.thing, everything[a.dataset.cat][a.dataset.thing]); return false; };
             });
         }
+        
+        // https://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
+        /* Randomize array in-place using Durstenfeld shuffle algorithm and return it */
+        function shuffleArray(array) {
+            for (var i = array.length - 1; i > 0; i--) {
+                var j = Math.floor(Math.random() * (i + 1));
+                var temp = array[i];
+                array[i] = array[j];
+                array[j] = temp;
+            }
+            return array
+        }
 
         function startQuiz(thing, inf)
         {
@@ -36,6 +48,8 @@
             const numTotalItems = itemGroups.reduce((p, n) => p + n.length, 0);
             const hasSounds = inf.SoundPath;
             const hasVideos = inf.VideoPath;
+
+            let questionsQueue = [];
 
             const quiz = document.getElementById('quiz');
             quiz.innerHTML = `
@@ -61,7 +75,14 @@
 
                 clearTimeout(timeout);
                 timeout = null;
-                let itemIx = (Math.random() * numTotalItems) | 0;
+                
+                //if queue is too small (needs at least length 4 to insert wrong answers back into), add copie(s) of all the questions to queue in a random order
+                while (questionsQueue.length < 4) {
+                    [].push.apply(questionsQueue, shuffleArray([...Array(numTotalItems).keys()]));
+                }
+                //get question from queue
+                let itemIx = questionsQueue.shift();
+
                 let groupIx = 0;
                 while (itemIx > itemGroups[groupIx].length) {
                     itemIx -= itemGroups[groupIx].length;
@@ -129,6 +150,9 @@
                             });
                             timeout = setTimeout(showQuestion, 700);
                         } else {
+                            //the option clicked was wrong; reinsert it to the queue, lets say in three questions
+                            questionsQueue.splice(3, 0, itemIx);
+
                             btn.classList.add('wrong');
                             document.getElementById('answers').querySelectorAll('button.correct-answer').forEach((item) => {
                                 item.classList.add('correct');

--- a/More/Quiz.html
+++ b/More/Quiz.html
@@ -4,6 +4,7 @@
     <meta name="viewport" content="initial-scale=1">
     <title>Quiz</title>
     <script src="QuizData.js"></script>
+    <script src="../HTML/js/Utilities/array-utils.js"></script>
     <script>
         let timeout;
         let mode = 2;
@@ -27,18 +28,6 @@
             Array.from(document.querySelectorAll('a.start')).forEach(a => {
                 a.onclick = function() { startQuiz(a.dataset.thing, everything[a.dataset.cat][a.dataset.thing]); return false; };
             });
-        }
-        
-        // https://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
-        /* Randomize array in-place using Durstenfeld shuffle algorithm and return it */
-        function shuffleArray(array) {
-            for (var i = array.length - 1; i > 0; i--) {
-                var j = Math.floor(Math.random() * (i + 1));
-                var temp = array[i];
-                array[i] = array[j];
-                array[j] = temp;
-            }
-            return array
         }
 
         function startQuiz(thing, inf)
@@ -78,7 +67,7 @@
                 
                 //if queue is too small (needs at least length 4 to insert wrong answers back into), add copie(s) of all the questions to queue in a random order
                 while (questionsQueue.length < 4) {
-                    [].push.apply(questionsQueue, shuffleArray([...Array(numTotalItems).keys()]));
+                    [].push.apply(questionsQueue, ShuffleFisherYates([...Array(numTotalItems).keys()]));
                 }
                 //get question from queue
                 let itemIx = questionsQueue.shift();

--- a/More/Quiz.html
+++ b/More/Quiz.html
@@ -49,7 +49,7 @@
             const hasSounds = inf.SoundPath;
             const hasVideos = inf.VideoPath;
 
-            let questionsQueue = [];
+            const questionsQueue = [];
 
             const quiz = document.getElementById('quiz');
             quiz.innerHTML = `


### PR DESCRIPTION
As discussed [here](https://discord.com/channels/160061833166716928/640557658482540564/1352869200590278678).
The quiz will now go through all questions once before repeating an ask -- except for when you answer incorrectly, in which case it will reinsert that question to be asked again four questions later.
Does not distinguish between key -> value and value -> key.