### PR TITLE
DeMiLMissionViewer: Sort mission packs by name and add Table of Contents info

### DIFF
--- a/More/DeMiLMissionViewer/index.html
+++ b/More/DeMiLMissionViewer/index.html
@@ -24,6 +24,9 @@
               filter.toLocaleLowerCase()
             )
           )
+          .sort((element, other) => {
+            return element.Title.localeCompare(other.Title)
+          })
           .map((mission) => {
             const $tr = document.createElement("tr");
             const $load = document.createElement("button");

--- a/More/DeMiLMissionViewer/missionDetail.html
+++ b/More/DeMiLMissionViewer/missionDetail.html
@@ -11,6 +11,7 @@
     />
     <script>
       var missionDetails;
+      var tocDetail;
       var moduleInfo;
 
       function showMessage(str, error=false) {
@@ -121,7 +122,14 @@
             (a, b) => a + b,
             0
           );
+
+          const $toc = document.createElement("span")
+          $toc.setAttribute("data-tooltip", mission.ToCTitle + " - " + mission.ToCSectionTitle)
+          $toc.setAttribute("data-tooltip-position", "top")
+          $toc.innerText = mission.ToCLetter + "\u00a0" + mission.ToCNum        
+
           const rows = [
+            $toc,
             mission.Title,
             mission.Description,
             mission.BombCount,
@@ -175,14 +183,49 @@
           getRepo(),
           (async () => {
             try {
-              missionDetails = await (
+              // Instead of missionDetail API call, do tocDetail call
+              // We will construct a combined tocDetail/missionDetail object from this
+              // The only thing that makes them different is either missions split by ToC sections (tocDetail), or a plain list of missions (missionDetail)
+              tocDetail = await (
                 await fetch(
-                  `http://localhost:8095/missionDetail?steamID=${steamID}`
+                  `http://localhost:8095/tocDetail?steamID=${steamID}`
                 )
               ).json();
             } catch {
               document.getElementById("demilError").className = "show";
             }
+
+            // Reduce tocDetail entries to a list of Missions (with added ToC data)
+            var toc_missions = tocDetail.ToCs.reduce((acc, cur, toc_index) => {
+              var sections = cur.Sections
+              
+              // Avoid making the table too wide, use letters as top level indices
+              // We will add a hover tooltip with the full name
+              // ASCII 65 = 'A'
+              var toc_letter = String.fromCharCode(65+toc_index)
+              var toc_title = cur.Title
+              
+              sections = sections.reduce((acc, cur) => {
+                var missions = cur.Missions
+                missions = missions.map((mission, toc_sec_index) => {
+                  // Add entries to every mission with ToC information
+                  mission.ToCTitle = toc_title
+                  mission.ToCSectionTitle = cur.Title
+                  mission.ToCLetter = toc_letter
+                  mission.ToCNum = cur.SectionNum + "." + (toc_sec_index + 1)
+                  return mission
+                })
+                return acc.concat(missions)
+              }, [])
+              return acc.concat(sections)
+            }, [])
+
+            // Add list of Missions to tocDetail object
+            tocDetail.Missions = toc_missions
+
+            // With the mission list added to tocDetails, it fulfills the structure of the object from the missionDetails API call.
+            // We assign this combined tocDetails/missionDetails object to missionDetails. Everything that relies on missionDetails still works
+            missionDetails = tocDetail
 
             setData(steamID);
             document.getElementsByTagName("h2")[0].innerHTML =
@@ -299,6 +342,126 @@
       input {
         margin: 8px;
       }
+      /* Tooltip styling modified version of Wenk (https://github.com/tiaanduplessis/wenk). */
+      /* MIT License */
+      /* Copyright © 2018 Tiaan du Plessis <tiaanduplessis@hotmail.com> */
+      :root {
+        --tooltip-font-size: 13px;
+        --tooltip-font-color: #fff;
+        --tooltip-bg-color: rgba(17, 17, 17, .8);
+        --tooltip-length-small: 80px;
+        --tooltip-length-medium: 150px;
+        --tooltip-length-large: 260px;
+      }
+      
+      [data-tooltip] {
+        cursor: help;
+        position: relative;
+        &:after {
+            position: absolute;
+            font-size: var(--tooltip-font-size);
+            border-radius: .4rem;
+            content: attr(data-tooltip);
+            padding: .8rem;
+            background-color: var(--tooltip-bg-color);
+            box-shadow: 0 0 14px rgba(0, 0, 0, 0.1);
+            color: var(--tooltip-font-color);
+            line-height: 1.25rem;
+            text-align: left;
+            z-index: 1;
+            pointer-events: none;
+            display: block;
+            opacity: 0;
+            visibility: hidden;
+            transition: all .1s;
+            bottom: 100%;
+            left: 50%;
+            transform: translate(-50%, 10px);
+            white-space: pre;
+            width: auto;
+        }
+        &:after {
+            opacity: 0;
+        }
+        &:hover {
+            overflow: visible;
+            &:after {
+                display: block;
+                opacity: 1;
+                visibility: visible;
+                transform: translate(-50%, -10px);
+            }
+        }
+    
+        &[data-tooltip-position="bottom"] {
+            &:after {
+                bottom: auto;
+                top: 100%;
+                left: 50%;
+                transform: translate(-50%, -10px);
+            }
+            &:hover {
+                &:after {
+                    transform: translate(-50%, 10px);
+                }
+            }
+        }
+    
+        &[data-tooltip-position="left"] {
+            &:after {
+                bottom: auto;
+                left: auto;
+                top: 50%;
+                right: 100%;
+                transform: translate(10px, -50%);
+            }
+            &:hover {
+                &:after {
+                    transform: translate(-10px, -50%);
+                }
+            }
+        }
+    
+        &[data-tooltip-position="right"] {
+            &:after {
+                bottom: auto;
+                top: 50%;
+                left: 100%;
+                transform: translate(-10px, -50%);
+            }
+            &:hover {
+                &:after {
+                    transform: translate(10px, -50%);
+                }
+            }
+        }
+    
+        &[data-tooltip-length="small"]:after {
+            white-space: normal;
+            width: var(--tooltip-length-small);
+        }
+        &[data-tooltip-length="medium"]:after {
+            white-space: normal;
+            width: var(--tooltip-length-medium);
+        }
+        &[data-tooltip-length="large"]:after {
+            white-space: normal;
+            width: var(--tooltip-length-large);
+        }
+        &[data-tooltip-length="fit"]:after {
+            white-space: normal;
+            width: 100%;
+        }
+    
+        &[data-tooltip-align="right"]:after {
+            text-align: right;
+        }
+        &[data-tooltip-align="center"]:after {
+            text-align: center;
+        }
+      }
+      /* End of modified Wenk tooltip styling. */ 
+      /* End of MIT Licensed code */
     </style>
   </head>
   <body>
@@ -310,6 +473,7 @@
       <table id="table">
         <thead>
           <tr>
+            <th>ToC</th>
             <th>Mission Name</th>
             <th>Description</th>
             <th>Bomb Count</th>


### PR DESCRIPTION
This is my first PR to this repository, if any more information is required, please let me know! Happy to make any changes!

# Problems
1. The mission pack entries in the DeMiL Mission Viewer are not sorted in a user-friendly order.
2. The missions in the details view are missing their in-game Table of Contents indices, making it hard for a user to know what the order of missions on this page is.

# Solutions
## 1.
This PR sorts the mission pack entries by name.

## 2.
This PR adds Table of Contents information as table entries, and entries are sorted in Table of Contents order (the default in the tocDetail API endpoint response). This is especially relevant for anyone doing "Introduction to Mods" mission packs, or any "Road to ..." mission pack. Now users can be confident what the intended order of the missions is, by their Table of Contents index.

If a mission pack adds multiple top-level Table of Contents entries (such as Road to Centurion adding "Road to Centurion" and "Best Of: Road to Centurion", the top-level entries will be split using letters ("A 1.1", "B 1.1", etc.). Adding the full top-level name would make the table too wide. The full top-level name, and the section names, are available as a tooltip when hovering over the index. (see video)

# Screenshots
## Main page
|                                          Before                                           |
| :---------------------------------------------------------------------------------------: |
| ![image](https://github.com/user-attachments/assets/7ba506dc-c31b-4df6-aa00-d773d2f227a6) |

|                                           After                                           |
| :---------------------------------------------------------------------------------------: |
| ![image](https://github.com/user-attachments/assets/0d90d202-f723-47a8-b64b-ac4047c91189) |

## Mission Detail page
|                                          Before                                           |
| :---------------------------------------------------------------------------------------: |
| ![image](https://github.com/user-attachments/assets/a5ae8d31-f9b2-4e7c-9d96-a69baf4c8366) |

|                                           After                                           |
| :---------------------------------------------------------------------------------------: |
| ![image](https://github.com/user-attachments/assets/e96d166e-26e9-4cb8-9de2-7f396405b5e7) |

## ToC Tooltips
https://github.com/user-attachments/assets/06f49397-624b-43a1-a30d-f21c96da935d

https://github.com/user-attachments/assets/074b80b0-9576-4d0b-8b81-88527fc75dfd