### PR TITLE
GeoGuessr: Fix Guatemala typo

### DIFF
--- a/HTML/GeoGuessr.html
+++ b/HTML/GeoGuessr.html
@@ -656,11 +656,11 @@
                         <td colspan="3"><b>Metas</b></td>
                     </tr> -->
 
-                    <!-- GT: Guatamala -->
+                    <!-- GT: Guatemala -->
                     <tr>
                         <td rowspan="2">
                             <b class="country-code">GT</b><br>
-                            Guatamala
+                            Guatemala
                         </td>
                         <th>Spanish language</th>
                         <th colspan="2">Google car</th>


### PR DESCRIPTION
- Fix Guatemala being spelt as Guatamala