### PR TITLE
Quintuples reworded (thunder725)

### DIFF
--- a/HTML/Quintuples reworded (thunder725).html
+++ b/HTML/Quintuples reworded (thunder725).html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="initial-scale=1">
+    <title>Quintuples reworded (thunder725) — Keep Talking and Nobody Explodes Module</title>
+    <link rel="stylesheet" type="text/css" href="css/font.css">
+    <link rel="stylesheet" type="text/css" href="css/normalize.css">
+    <link rel="stylesheet" type="text/css" href="css/main.css">
+    <script src="js/ktane-utils.js"></script>
+    <script src="js/jquery.3.7.0.min.js"></script>
+    <script>
+        $(function () {
+            const colouredText = $(".coloured");
+        
+            $(".coloured-setting input").on("change", function() {
+                $(".coloured").toggleClass("black");
+            }).change();
+        });
+    </script>
+    <style>
+        .condition-table {
+            margin: 1em auto;
+            border: none;
+        }
+        .accentuated {
+            text-decoration: underline;
+        }
+        .r {
+            color: #aa0000;
+        }
+        .o {
+            color: #cd5200;
+        }
+        .g {
+            color: #046604;
+        }
+        .b {
+            color: #0000cc;
+        }
+        .i {
+            color: #e50ee5;
+        }
+        .dark .r {
+            color: #ff7b7b;
+        }
+        .dark .o {
+            color: #ffa763;
+        }
+        .dark .g {
+            color: #61ff61;
+        }
+        .dark .b {
+            color: #85a7ff;
+        }
+        .dark .i {
+            color: #ee97ee;
+        }
+        .black {
+            color: #222;
+        }
+        .dark .black{
+            color: #ddd;
+        }
+    </style>
+</head>
+<body>
+    <div class="section">
+        <div class="page page-bg-03">
+            <div class="page-header">
+                <span class="page-header-doc-title">Keep Talking and Nobody Explodes Mod</span>
+                <span class="page-header-section-title">Quitting Quintuples</span>
+            </div>
+            <div class="page-content">
+                <img src="img/Component/Quintuples.svg" class="diagram">
+                <h2>On the Subject of Quitting Quintuples</h2>
+                <p class="flavour-text">“Quintuples” has its roots in Royal_Flu$h modules. There are lots of Royal_Flu$h modules.</p>
+
+                <ul>
+                    <li>The following manual contains the table from the <a href="Quintuples.html">original manual</a>, transposed to note individual slots horizontally.</li>
+                    <li>For each slot on the module, note down (in rows) the five digits and colours it displays.</li>
+                    <li>If a digit is of the colour shown in the table, apply the Match Rule to it.</li>
+                    <li>After that, sum the digits by column, applying the correct modulo operations.</li>
+                    <li>Input the result of those sums/modulos on the module in order.</li>
+                    <li><b class="accentuated">Treat any 0s (zeros) received from the display as 10s.</b></li>
+                </ul>
+                <table class='condition-table'>
+                    <tr>
+                        <th colspan="2" rowspan="2" class='no-border'><span class="coloured-setting">Coloured text: <input type="checkbox"></span></th>
+                        <th colspan="5">DIGIT INDEX</th>
+                        <th class='corner'></th>
+                    </tr>
+                    <tr>
+                        <th>1</th>
+                        <th>2</th>
+                        <th>3</th>
+                        <th>4</th>
+                        <th>5</th>
+                        <th>MATCH RULE</th>
+                    </tr>
+                    <tr>
+                        <th rowspan="5">S<br>L<br>O<br>T<br> <br>P<br>O<br>S<br>I<br>T<br>I<br>O<br>N</th>
+                        <th>1</th>
+                        <td><span class="coloured r">Red</span><br><span class="coloured o">Orange</span></td>
+                        <td><span class="coloured b">Blue</span></td>
+                        <td><span class="coloured o">Orange</span></td>
+                        <td><span class="coloured g">Green</span></td>
+                        <td><span class="coloured i">Pink</span><br><span class="coloured b">Blue</span></td>
+                        <td>+7</td>
+                    </tr>
+                    <tr>
+                        <th>2</th>
+                        <td><span class="coloured b">Blue</span></td>
+                        <td><span class="coloured i">Pink</span><br><span class="coloured r">Red</span></td>
+                        <td><span class="coloured r">Red</span></td>
+                        <td><span class="coloured o">Orange</span><br><span class="coloured i">Pink</span></td>
+                        <td><span class="coloured g">Green</span></td>
+                        <td>+13</td>
+                    </tr>
+                    <tr>
+                        <th>3</th>
+                        <td><span class="coloured i">Pink</span></td>
+                        <td><span class="coloured o">Orange</span></td>
+                        <td><span class="coloured g">Green</span><br><span class="coloured o">Orange</span></td>
+                        <td><span class="coloured b">Blue</span><br><span class="coloured g">Green</span></td>
+                        <td><span class="coloured r">Red</span></td>
+                        <td>*2</td>
+                    </tr>
+                    <tr>
+                        <th>4</th>
+                        <td><span class="coloured g">Green</span></td>
+                        <td><span class="coloured r">Red</span></td>
+                        <td><span class="coloured b">Blue</span><br><span class="coloured g">Green</span></td>
+                        <td><span class="coloured i">Pink</span></td>
+                        <td><span class="coloured o">Orange</span><br><span class="coloured r">Red</span></td>
+                        <td>*3</td>
+                    </tr>
+                    <tr>
+                        <th>5</th>
+                        <td><span class="coloured o">Orange</span><br><span class="coloured b">Blue</span></td>
+                        <td><span class="coloured g">Green</span><br><span class="coloured i">Pink</span></td>
+                        <td><span class="coloured i">Pink</span></td>
+                        <td><span class="coloured r">Red</span></td>
+                        <td><span class="coloured b">Blue</span></td>
+                        <td>/2 (rounded down)</td>
+                    </tr>
+                    <tr>
+                        <th colspan="2">SUM &amp; MODULOS</th>
+                        <th>Sum;<br>Modulo (<span class="coloured r">Red</span> + <span class="coloured o">Orange</span> flashes);<br>Modulo 10</th>
+                        <th>Sum;<br>Modulo (<span class="coloured b">Blue</span> + <span class="coloured i">Pink</span> flashes);<br>Modulo 10</th>
+                        <th>Sum;<br>Modulo (<span class="coloured r">Red</span> + <span class="coloured g">Green</span> flashes);<br>Modulo 10</th>
+                        <th>Sum;<br>Modulo (<span class="coloured b">Blue</span> + <span class="coloured o">Orange</span> flashes);<br>Modulo 10</th>
+                        <th>Digit of the tens position + <span class="coloured i">Pink</span> flashes + <span class="coloured g">Green</span> flashes;<br>Modulo 10</th>
+                    </tr>
+                </table>
+            </div>
+            <div class="page-footer relative-footer">Page 1 of 1</div>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Added reworded manual for the module Quintuples:
Transposes the table to be read vertically instead of horizontally, rewords the top sentences to match, and adds an option to colourize the text if wanted.
Reworded credit to thunder725. Original manual by Royal_Flu$h.