### PR TITLE
Fixed Scorching Alchemist icons on mobile

### DIFF
--- a/HTML/Scorching Alchemist.html
+++ b/HTML/Scorching Alchemist.html
@@ -30,6 +30,7 @@
         
         .weapon-icon {
             width: 90%;
+			min-width: 3em;
         }
         
         .weapon-table {


### PR DESCRIPTION
Icons inside the Scorching Alchemist manual appeared too small on mobile as seen here: https://discord.com/channels/160061833166716928/640557658482540564/1503813987505279017

This commit aims to fix that.