### PR TITLE
Misc Mythical Plate changes

### DIFF
--- a/HTML/Allmighty Sinnoh.html
+++ b/HTML/Allmighty Sinnoh.html
@@ -221,7 +221,7 @@
                     <tr>
                         <td>8</td>
                         <td class="spooky"></td>
-                        <td>Purple Plate with 3 digits.</td>
+                        <td>Pale purple Plate with 3 digits.</td>
                         <td><a>Spooky Plate</a></td>
                     </tr>
                     <tr>
@@ -257,7 +257,7 @@
                     <tr>
                         <td>14</td>
                         <td class="mind"></td>
-                        <td>Pink Plate with a constellation drawing.</td>
+                        <td>Hot pink Plate with a constellation drawing.</td>
                         <td><a>Mind Plate</a></td>
                     </tr>
                     <tr>

--- a/HTML/Blank Plate.html
+++ b/HTML/Blank Plate.html
@@ -79,12 +79,12 @@
                         His next movement will only take effect on the 4th tile.
                     </li>
                 </ul>
-                <p>Pablo always starts on an Obstacle-less Tile, before the Path starts. The first button press represent the action he does on the first tile.</p>
+                <p>Pablo always starts on an Obstacle-less Tile (position 0), before the Path starts. The first button press represents the action he does on the first tile.</p>
                 <p>
                     Generate the Path using instructions on page 2.<br>
                     Then, the numbers on the Plate indicate which tile numbers to Void.
                 </p>
-                <p class="inline-secondary">The first tile is numbered 0, not 1.</p>
+                <p class="inline-secondary">The first tile of the Path you construct has position 1.</p>
 
                 <p>Voided Tiles are considered to not exist, entirely skip over them when Pablo moves forward.</p>
                 <p>

--- a/HTML/Dread Plate.html
+++ b/HTML/Dread Plate.html
@@ -57,6 +57,7 @@
             font-weight: bold;
             white-space: nowrap;
             color: #00A0FF;
+            user-select: none;
         }
         .dread-number .f { color: #FF0000; }
 
@@ -86,7 +87,7 @@
                     <b class="emphasis">Do not forget about Voided Words.</b> Loop back if you go out of the text.<br>
                     Hyphenated words such as “Medium-Sized” count as 2 words, while words with apostrophes such as “You’re” count as 1.
                 </p>
-                <p>Append both words together, <b class="emphasis">starting by the end one</b>, and remove duplicate letters (keeping only the first occurrence).</p>
+                <p>Concatenate both words together, <b class="emphasis">starting by the one obtained from the end of the text</b>, and remove duplicate letters (keeping only the first occurrence).</p>
                 <p>Replace every letter with its symbol. This is your <b class="emphasis">Character Sequence.</b></p>
                 <table>
                     <tr>

--- a/HTML/Dread Plate.html
+++ b/HTML/Dread Plate.html
@@ -87,7 +87,7 @@
                     <b class="emphasis">Do not forget about Voided Words.</b> Loop back if you go out of the text.<br>
                     Hyphenated words such as “Medium-Sized” count as 2 words, while words with apostrophes such as “You’re” count as 1.
                 </p>
-                <p>Concatenate both words together, <b class="emphasis">starting by the one obtained from the end of the text</b>, and remove duplicate letters (keeping only the first occurrence).</p>
+                <p>Concatenate both words together, <b class="emphasis">starting with the word obtained from the end of the text</b>, and remove duplicate letters (keeping only the first occurrence).</p>
                 <p>Replace every letter with its symbol. This is your <b class="emphasis">Character Sequence.</b></p>
                 <table>
                     <tr>

--- a/HTML/Earth Plate.html
+++ b/HTML/Earth Plate.html
@@ -91,7 +91,7 @@
                     You need to land on the ending cell at the end of your movement, not during.</p>
                     <p>A Voided cell is considered to not exist. For more information about Voided Cells, see <b class="appendix-name">Shared Appendix V O I D</b>.</p>
                     <p>You cannot wrap around the grid.</p>
-                    <p>Look into <b class="appendix-name">Table CLYDESDALE</b>, for each Port type, if it is present on the bomb, Void in Grid STAMINA the column and line marked with this number.</p>
+                    <p>Look into <b class="appendix-name">Table CLYDESDALE</b>, for each Port type, if it is present on the bomb, Void in Grid STAMINA the column and row marked with this number.</p>
                     <h3>Table CLYDESDALE:</h3>
                     <table class="port-table">
                         <tr><th>Port Name:</th><td>Serial</td><td>Stereo RCA</td><td>PS/2</td><td>DVI-D</td><td>RJ-45</td><td>Parallel</td></tr>

--- a/HTML/Flame Plate.html
+++ b/HTML/Flame Plate.html
@@ -52,11 +52,6 @@
             font-weight: normal;
         }
 
-        var {
-            font-weight: bold;
-            font-style: normal;
-        }
-
         b.passcode { font-weight: normal; }
 
         td.starting-cell { background-color: #ff3c3c7a; }

--- a/HTML/Meadow Plate.html
+++ b/HTML/Meadow Plate.html
@@ -72,7 +72,7 @@
 
                 <p>
                     The plate on the module is inscribed with the name of four plants that you want to grow.<br>
-                    It also can be pressed in one of twelve spots, corresponding to the twelves months of the year.
+                    It also can be pressed in one of twelve spots, corresponding to the twelve months of the year.
                 </p>
                 <table class="plate-keypad-table">
                     <tr><th colspan="3">Months Button Position</th></tr>
@@ -91,7 +91,7 @@
                     For example, if a plant is plantable in February, March, April and September, and the Voided month is March; its Feb-Mar-Apr gets extended to May while its Sep doesn’t get affected by the Void.<br>
                     Note that December is continuous with January.
                 </p>
-                <p>To determine which month is Voided, sum all Serial Number digits, and subtract or add 12 from it until it is in the range 1-12. The corresponding month is the one that is Voided for you (January being 1 and December being 12).</p>
+                <p>To determine which month is Voided, sum all Serial Number digits, and subtract or add 12 until it is in the range 1-12. The corresponding month is the one that is Voided for you (January being 1 and December being 12).</p>
             </div>
             <div class="page-footer relative-footer">1</div>
         </div>

--- a/HTML/Mind Plate.html
+++ b/HTML/Mind Plate.html
@@ -75,7 +75,7 @@
                 <p>Use the buttons on the sides of the plate to move around the Rubik’s Cube, and the center one to submit the Star on your current location.</p>
                 <p>
                     Find in <b class="appendix-name">Appendix ANISTAR</b> your Constellation and how it fits on the net representing your Rubik’s Cube.<br>
-                    That net will also give you the location of the Voided Cells.<br>
+                    That net will also give you the location of the Voided Cells, in black.<br>
                     See <b class="appendix-name">Shared Appendix V O I D</b> for more information about Voided Cells.
                 </p>
                 <p>
@@ -112,6 +112,7 @@
                 <h3>Appendix ANISTAR:</h3>
                 <p>Coordinates are used by naming faces in reading order I through VI, and then using regular coordinates A1-to-C3 for each individual face.</p>
                 <p class="inline-secondary">Example: Stars in the first net have coordinates I-C2, II-C2, II-B3, III-B2, IV-C1, IV-B3 and V-B2.</p>
+                <p>Face I is the Up face, II is the Left face, III is the Front face, etc.</p>
                 <p>The dotted lines in-between stars only serve for Constellation recognition and do not affect the solving process.</p>
                 <div class="constellation-holder">
                     <img src="img/Mind Plate/Latias Net.svg" class="constellation invertible">

--- a/HTML/Pixie Plate.html
+++ b/HTML/Pixie Plate.html
@@ -53,7 +53,7 @@
                 <p>The Plate on the module is an interface to play a modified version of “Demons &amp; Pixies”, a popular tower-defense game. It also contains encrypted information about the game’s starting state.</p>
                 <h3>Rules of Demons &amp; Pixies:</h3>
                 <p>
-                    In an 8x4 horizontal grid, some Demons start on right side and move left. If one leaves the grid from the left, you lose.<br>
+                    In an 8x4 horizontal grid, some Demons start near the right side and move left. If one leaves the grid from the left, you lose.<br>
                     Thankfully, you get a set of Pixies you can summon to defend you.
                 </p>
                 <p>

--- a/HTML/Sky Plate.html
+++ b/HTML/Sky Plate.html
@@ -103,7 +103,7 @@
                     To fly to a city, input the city’s letter as Morse on the Plate.<br>
                     The buttons represent a dot or a dash, while the last submits the current letter.
                 </p>
-                <p>Submitting an unknown Morse, a city you cannot fly to from your current city, or having your Timer reach 0 outside of your target city will issue a Strike, <b class="emphasis">and reset you to your starting city with your starting Timer</b>.</p>
+                <p>Submitting an invalid Morse, a city you cannot fly to from your current city, or having your Timer reach 0 outside of your target city will issue a Strike, <b class="emphasis">and reset you to your starting city with your starting Timer</b>.</p>
                 <p>Landing on your target city with the Timer below 10 minutes will Solve the module, as it reaches 0 after Waiting for the Next Plane to Arrive.</p>
                 <p class="inline-secondary">You <b class="emphasis">can</b> fly to your target city before your Timer reaches 0. This won't solve the module nor strike.</p>
                 <p>In case it is needed, press the “SKY” text on the module casing to reset to your starting city with your starting Timer.</p>

--- a/HTML/Spooky Plate.html
+++ b/HTML/Spooky Plate.html
@@ -100,7 +100,7 @@
                 </p>
                 <ul>
                     <li>Concatenate all Serial Number digits as well as 487. Take the Digital Root* of this number. <b class="list-emphasis">If the result is 9</b>, use 7 instead.</li>
-                    <li>Look into <b class="appendix-name">Table PLATNIUM</b>. For each Port Type, if it is present, add the associated value to your number. Do not add the same value multiple times.</li>
+                    <li>Look into <b class="appendix-name">Table PLATINUM</b>. For each Port Type, if it is present, add the associated value to your number. Do not add the same value multiple times.</li>
                     <li>
                         If there are more Unlit Indicators than Lits, multiply the number by 3.<br>
                         <b class="list-emphasis">Otherwise</b> if the number of Lits and Unlits is equal, multiply it by 2.
@@ -108,19 +108,19 @@
                     <li>You should have a number in the range [0-342]. Convert it into base-7 to get a number between 000 and 666. <b class="list-emphasis">Keep all three digits</b>.</li>
                 </ul>
                 <p class="inline-secondary">*Continuously sum its digits until only one digit is remaining.</p>
-                <p>Consider the first digit to be “a”, the second to be “b” and the third to be “c”.</p>
-                <p class="inline-secondary">For example, for 014, “a” = 0, “b” = 1 and “c” = 4.</p>
+                <p>Consider the first digit to be “<var>a</var>”, the second to be “<var>b</var>” and the third to be “<var>c</var>”.</p>
+                <p class="inline-secondary">For example, for 014, “<var>a</var>” = 0, “<var>b</var>” = 1 and “<var>c</var>” = 4.</p>
                 <p>
-                    Void the line numbered “a” in first Floor, “b” in second Floor and “c” in third Floor.<br>
+                    Void the line numbered “<var>a</var>” in first Floor, “<var>b</var>” in second Floor and “<var>c</var>” in third Floor. Empty, non-walkable cells also get Voided.<br>
                     For more information, see <b class="appendix-name">Shared Appendix V O I D</b>.
                 </p>
                 <p>To move around in a Floor, press the edges of the Plate. Go from the Start to the End of each Floor. A sound will play when you successfully change Floor.</p>
-                <p>Attempting to move into an empty, non-walkable cell will issue a Strike and not move you.</p>
+                <p>Attempting to move into an empty, non-walkable cell will issue a Strike and not move you; unless that cell is Voided and the other side is walkable.</p>
                 <p>
                     In case it is needed, press the word “SPOOKY” on the module’s casing to reset you to the Start of the current Floor.<br>
                     A sound will play once, twice or thrice depending on if you are on your first, second or third Floor.
                 </p>
-                <h3>Table PLATNIUM:</h3>
+                <h3>Table PLATINUM:</h3>
                 <table class="ports">
                     <tr><th>Stereo RCA</th><th>PS/2</th><th>Serial</th><th>RJ-45</th><th>DVI-D</th><th>Parallel</th></tr>
                     <tr><th>1</th><th>7</th><th>14</th><th>21</th><th>28</th><th>35</th></tr>
@@ -141,7 +141,7 @@
                 </table>
                 <div class="floor-container">
                     <table class="floor-grid"> <!--"Hole Field 1" grid-->
-                        <tr><th colspan="9">Floor 1</th></tr>
+                        <caption class="highlightable">Floor 1</caption>
                         <tr><th></th><th>0</th><th>1</th><th>2</th><th>3</th><th>4</th><th>5</th><th>6</th><th></th></tr>
                         <tr><td></td><td></td><td class="cell"></td><td></td><td class="cell"></td><td></td><td></td><td></td><td></td></tr>
                         <tr><td class="cell end"></td><td></td><td class="cell"></td><td class="cell"></td><td class="cell"></td><td></td><td class="cell"></td><td class="cell"></td><td></td></tr>
@@ -150,7 +150,7 @@
                         <tr><td></td><td class="cell"></td><td class="cell"></td><td class="cell"></td><td class="cell"></td><td></td><td class="cell"></td><td class="cell"></td><td></td></tr>
                     </table>
                     <table class="floor-grid"> <!--"Easy" grid-->
-                        <tr><th colspan="6">Floor 2</th></tr>
+                        <caption class="highlightable">Floor 2</caption>
                         <tr><th></th><th></th><th></th><th>5</th><th>6</th><th></th></tr>
                         <tr><th></th><td></td><td></td><td class="cell"></td><td class="cell"></td><td class="start cell"></td></tr>
                         <tr><th>0</th><td></td><td></td><td class="cell"></td><td class="cell"></td><td></td></tr>
@@ -161,7 +161,7 @@
                         <tr><th></th><td class="cell"></td><td class="cell end"></td><td></td><td></td><td></td></tr>
                     </table>
                     <table class="floor-grid"> <!--"Large Holes" grid-->
-                        <tr><th colspan="8">Floor 3</th></tr>
+                        <caption class="highlightable">Floor 3</caption>
                         <tr><th></th><th>2</th><th></th><th>3</th><th>4</th><th>5</th><th>6</th><th></th></tr>
                         <tr><th></th><td class="cell"></td><td class="cell end"></td><td class="cell"></td><td class="cell"></td><td class="cell"></td><td class="cell"></td><td></td></tr>
                         <tr><th></th><td></td><td class="cell"></td><td></td><td class="cell"></td><td></td><td class="cell"></td><td class="cell start"></td></tr>
@@ -169,7 +169,7 @@
                         <tr><th>1</th><td></td><td></td><td></td><td class="cell"></td><td class="cell"></td><td class="cell"></td><td class="cell"></td></tr>
                     </table>
                     <table class="floor-grid"> <!--"Double Way 1" grid-->
-                        <tr><th colspan="7">Floor 4</th></tr>
+                        <caption class="highlightable">Floor 4</caption>
                         <tr><th></th><th>0</th><th></th><th>1</th><th></th><th>2</th><th>3</th></tr>
                         <tr><th></th><td></td><td></td><td class="cell"></td><td></td><td class="cell"></td><td class="cell"></td></tr>
                         <tr><th>4</th><td class="cell"></td><td class="cell"></td><td class="cell"></td><td class="cell"></td><td class="cell"></td><td class="cell"></td></tr>
@@ -179,7 +179,7 @@
                         <tr><th>6</th><td class="cell"></td><td class="cell"></td><td class="cell"></td><td></td><td></td><td></td></tr>
                     </table>
                     <table class="floor-grid"> <!--"Hole Field 2" grid-->
-                        <tr><th colspan="7">Floor 5</th></tr>
+                        <caption class="highlightable">Floor 5</caption>
                         <tr><th></th><th></th><th></th><th>0</th><th>1</th><th></th><th></th></tr>
                         <tr><th></th><td class="cell"></td><td class="cell start"></td><td class="cell"></td><td></td><td></td><td></td></tr>
                         <tr><th>2</th><td class="cell"></td><td></td><td class="cell"></td><td class="cell"></td><td class="cell"></td><td></td></tr>
@@ -190,7 +190,7 @@
                         <tr><th></th><td class="cell"></td><td></td><td class="cell"></td><td class="cell"></td><td class="cell end"></td><td></td></tr>
                     </table>
                     <table class="floor-grid"> <!--"Double Way 2" grid-->
-                        <tr><th colspan="8">Floor 6</th></tr>
+                        <caption class="highlightable">Floor 6</caption>
                         <tr><th></th><th></th><th>3</th><th>4</th><th>5</th><th>6</th><th></th><th></th></tr>
                         <tr><th>0</th><td class="cell"></td><td class="cell"></td><td class="cell"></td><td class="cell"></td><td></td><td></td><td></td></tr>
                         <tr><th>1</th><td class="cell"></td><td class="cell"></td><td></td><td class="cell"></td><td class="cell"></td><td class="cell"></td><td></td></tr>
@@ -200,7 +200,7 @@
                         <tr><th></th><td></td><td></td><td class="cell"></td><td class="cell"></td><td></td><td></td><td></td></tr>
                     </table>
                     <table class="floor-grid"> <!--"Hook" grid-->
-                        <tr><th colspan="7">Floor 7</th></tr>
+                        <caption class="highlightable">Floor 7</caption>
                         <tr><th></th><th></th><th>4</th><th></th><th>5</th><th></th><th>6</th></tr>
                         <tr><th></th><td></td><td></td><td class="cell end"></td><td class="cell"></td><td></td><td></td></tr>
                         <tr><th>0</th><td></td><td></td><td class="cell"></td><td class="cell"></td><td></td><td class="cell"></td></tr>
@@ -211,7 +211,7 @@
                         <tr><th></th><td class="cell"></td><td class="cell"></td><td class="cell"></td><td class="cell"></td><td class="cell"></td><td></td></tr>
                     </table>
                     <table class="floor-grid"> <!--"Inside-Out" grid-->
-                        <tr><th colspan="8">Floor 8</th></tr>
+                        <caption class="highlightable">Floor 8</caption>
                         <tr><th></th><th></th><th>0</th><th>1</th><th></th><th></th><th>2</th><th>3</th></tr>
                         <tr><th></th><td></td><td class="cell"></td><td class="cell"></td><td class="cell"></td><td></td><td class="cell"></td><td></td></tr>
                         <tr><th>4</th><td></td><td class="cell"></td><td class="cell"></td><td class="cell"></td><td class="cell"></td><td class="cell"></td><td class="cell"></td></tr>
@@ -222,7 +222,7 @@
                         <tr><th></th><td></td><td class="cell"></td><td class="cell"></td><td class="cell end"></td><td class="cell"></td><td class="cell"></td><td></td></tr>
                     </table>
                     <table class="floor-grid"> <!--"Minimalist" grid-->
-                        <tr><th colspan="6">Floor 9</th></tr>
+                        <caption class="highlightable">Floor 9</caption>
                         <tr><th></th><th>0</th><th></th><th>1</th><th>2</th><th></th></tr>
                         <tr><th></th><td></td><td class="cell"></td><td class="cell"></td><td class="cell"></td><td class="cell"></td></tr>
                         <tr><th></th><td class="cell"></td><td class="cell"></td><td></td><td class="cell"></td><td class="cell end"></td></tr>

--- a/HTML/Toxic Plate.html
+++ b/HTML/Toxic Plate.html
@@ -45,12 +45,12 @@
                     Upon entering a Voided Room, keep moving until exiting into a non-Voided Room:
                 </p>
                 <ul>
-                    <li>If only one other door exist, exit through it</li>
+                    <li>If only one other door exists, exit through it</li>
                     <li>Otherwise, exit through the doorway in the same direction you just took.</li>
                     <li>Otherwise, exit through the doorway that is cardinally clockwise from the direction you took (North &gt; East, East &gt; South, etc.)</li>
                 </ul>
                 <p>
-                    <b class="emphasis">After each of your movement</b>, the Void will move around and change rooms.<br>
+                    <b class="emphasis">After movement</b>, the Void will move around and change rooms.<br>
                     On its first ever movement, it moves through the North door (or the first cardinally clockwise if there is none).
                 </p>
                 <p class="inline-secondary">

--- a/HTML/css/Modules/Mythical Plates.css
+++ b/HTML/css/Modules/Mythical Plates.css
@@ -58,6 +58,11 @@ table {
     border: none;
 }
 
+var {
+    font-weight: bold;
+    font-style: normal;
+}
+
 .void-diagram { width: 90%; }
 
 .void-flex {

--- a/JSON/Pixie Plate.json
+++ b/JSON/Pixie Plate.json
@@ -1,7 +1,7 @@
 {
   "Author": "thunder725",
   "DefuserDifficulty": "Easy",
-  "Description": "Place wisely your Pixies so they can defent you from Demon assaults in this Voided tower defense. Tags: light-pink, numbers, letters, plate, plaque, rock, stone, 5-buttons",
+  "Description": "Place wisely your Pixies so they can defend you from Demon assaults in this Voided tower defense. Tags: light-pink, numbers, letters, plate, plaque, rock, stone, 5-buttons",
   "ExpertDifficulty": "VeryHard",
   "ModuleID": "PixiePlate",
   "Name": "Pixie Plate",


### PR DESCRIPTION
- Changed the colour descriptions of the Spooky and Mind Plates to differentiate them from Toxic and Pixie respectively.
- Updated Blank Plate to explain that the path starts at tile number 1, not 0.
- Made the numbers in page 2 of Dread Plate not selectable. Also rephrased a line in page 1.
- Transferred var styling to the group CSS, and added the tag in Spooky Plate.
- Added more precision for the orientation of the net in Mind Plate.
- Made Floor numbers in Spooky Plate use the caption tag.
- Corrected grammar in Earth, Meadow, Pixie, Sky, Spooky, and Toxic Plate.
- Fixed typo in Spooky Plate and Pixie's JSON.